### PR TITLE
Clean up geometry primitives

### DIFF
--- a/docs/REVIEW.md
+++ b/docs/REVIEW.md
@@ -1,0 +1,18 @@
+# Code quality observations
+
+This document highlights potentially deprecated or poor-practice patterns spotted in the current codebase. The aim is to guide future refactors toward safer and more idiomatic C++.
+
+## Excess copying and missing const-correctness
+- Geometry helpers and the framebuffer expose getters that return mutable data by value without being `const`, leading to needless copies and preventing use on `const` instances. Examples include `FrameBuffer::getImg`, `FrameBuffer::getW`, and similar accessors across geometry types that should be `const` and return references or values without copying the entire buffer.
+
+## Unnecessary ownership declarations and manual destruction
+- Several geometry classes manually clear `std::vector` members inside destructors (`~Circle`, `~Rectangle`, `~Triangle`, `~Line`) even though the rule of zero would handle cleanup automatically. The explicit clears add noise and risk double-work if future ownership logic changes.
+
+## Header dependencies that bloat compile times
+- `include/geo-prims.h` pulls in `<iostream>` even though the header only declares data containers and geometry helpers. Removing unused heavy headers reduces rebuild costs and keeps interfaces cleaner.
+
+## Public data members that bypass invariants
+- `FrameBuffer::img` and the map dimensions (`Map::w`/`Map::h`) are public, allowing external code to mutate state without bounds checks or resize synchronization. Encapsulating these fields behind accessors would protect invariants like buffer size matching width/height.
+
+## Copy-returned coordinate buffers
+- Geometry `getCoords` methods currently return `std::vector<int>` by value, forcing allocations each time coordinates are fetched. Returning `const std::vector<int>&` (or views) would avoid repeated copies when primitives are reused across frames.

--- a/include/framebuffer.h
+++ b/include/framebuffer.h
@@ -7,33 +7,81 @@
 #ifndef FRAMEBUFFER_H
 #define FRAMEBUFFER_H
 
+/**
+ * @brief Lightweight pixel container used for all on-screen drawing.
+ *
+ * FrameBuffer owns a contiguous RGBA buffer and provides tiny helper
+ * routines for plotting pixels, clearing the screen, and drawing the simple
+ * geometric primitives that other systems rely on (e.g. the mini-map overlay
+ * and sky/ground fills).
+ */
 class FrameBuffer
 {
     private:
-	size_t w, h;
+        size_t w, h;
 
     public:
-	std::vector<uint32_t> img;
+        /// Raw RGBA pixel buffer sized to w * h.
+        std::vector<uint32_t> img;
 
-	std::vector<uint32_t> getImg () { return img; }
-	size_t getW () { return w; }
-	size_t getH () { return h; }
-	void setW (size_t wide) { w = wide; }
-	void setH (size_t height) { h = height; }
-	void drawOver (std::vector<int> coords, uint32_t color);
+        /**
+         * @brief Return a copy of the backing pixel buffer.
+         */
+        std::vector<uint32_t> getImg () { return img; }
+        /**
+         * @brief Current framebuffer width in pixels.
+         */
+        size_t getW () { return w; }
+        /**
+         * @brief Current framebuffer height in pixels.
+         */
+        size_t getH () { return h; }
+        /**
+         * @brief Set framebuffer width. Callers must resize img themselves.
+         */
+        void setW (size_t wide) { w = wide; }
+        /**
+         * @brief Set framebuffer height. Callers must resize img themselves.
+         */
+        void setH (size_t height) { h = height; }
 
-	void clear (const uint32_t color);
-	uint32_t getPixel (const size_t x, const size_t y);
-	void setPixel (const size_t iX, const size_t iY, const uint32_t color);
-	void drawTriangle (const int x1,
-			   const int y1,
-			   const int x2,
-			   const int y2,
-			   const int x3,
-			   const int y3,
-			   const uint32_t color);
-	void drawPolygon (Polygon poly);
-	bool isPixel (const int x, const int y) const;
+        /**
+         * @brief Alpha-blend a primitive's coordinates on top of the buffer.
+         * @param coords Flattened list of x/y pairs produced by a geo primitive.
+         * @param color  RGBA color to blend onto the destination pixels.
+         */
+        void drawOver (std::vector<int> coords, uint32_t color);
+
+        /**
+         * @brief Fill the entire buffer with a solid color.
+         */
+        void clear (const uint32_t color);
+        /**
+         * @brief Safely fetch a pixel at (x, y).
+         */
+        uint32_t getPixel (const size_t x, const size_t y);
+        /**
+         * @brief Plot a pixel at (iX, iY) without clipping.
+         */
+        void setPixel (const size_t iX, const size_t iY, const uint32_t color);
+        /**
+         * @brief Draw a filled triangle directly into the buffer.
+         */
+        void drawTriangle (const int x1,
+                           const int y1,
+                           const int x2,
+                           const int y2,
+                           const int x3,
+                           const int y3,
+                           const uint32_t color);
+        /**
+         * @brief Draw a filled polygon produced by the geometry helpers.
+         */
+        void drawPolygon (Polygon poly);
+        /**
+         * @brief Check whether a coordinate lies inside the buffer bounds.
+         */
+        bool isPixel (const int x, const int y) const;
 };
 
 #endif // FRAMEBUFFER_H

--- a/include/geo-prims.h
+++ b/include/geo-prims.h
@@ -1,213 +1,258 @@
 #include <cstdint>
 #include <cstdlib>
-#include <iostream>
 #include <vector>
 
 #ifndef GEO_PRIMS_H
 #define GEO_PRIMS_H
 
+/**
+ * @brief Simple geometry helpers used to draw overlays and masks.
+ *
+ * These primitives return flattened coordinate lists that FrameBuffer can
+ * quickly blend. They intentionally avoid heavy dependencies so newcomers can
+ * explore basic rasterization concepts.
+ */
 class Point
 {
     private:
-	int x, y;
+        int x, y;
 
     public:
-	int getX () { return x; }
-	int getY () { return y; }
-	void setX (int setX) { x = setX; }
-	void setY (int setY) { y = setY; }
-	Point (int a, int b)
-	{
-		x = a;
-		y = b;
-	}
-	Point () {}
+        int getX () const { return x; }
+        int getY () const { return y; }
+        void setX (int setX) { x = setX; }
+        void setY (int setY) { y = setY; }
+        Point (int a, int b)
+        {
+                x = a;
+                y = b;
+        }
+        Point () {}
 };
 
+/**
+ * @brief Discrete circle represented by precomputed perimeter points.
+ */
 class Circle
 {
     private:
-	Point origin;
-	size_t radius;
-	uint32_t color;
-	std::vector<int> coord;
+        Point origin;
+        size_t radius;
+        uint32_t color;
+        std::vector<int> coord;
 
     public:
-	uint32_t getColor () { return color; }
-	void setColor (uint32_t rgba) { color = rgba; }
+        uint32_t getColor () const { return color; }
+        void setColor (uint32_t rgba) { color = rgba; }
 
-	int getX () { return origin.getX (); }
-	int getY () { return origin.getY (); }
+        int getX () const { return origin.getX (); }
+        int getY () const { return origin.getY (); }
 
-	void setX (int setX) { origin.setX (setX); }
-	void setY (int setY) { origin.setY (setY); }
+        void setX (int setX) { origin.setX (setX); }
+        void setY (int setY) { origin.setY (setY); }
 
-	void setRad (size_t rad) { radius = rad; }
-	size_t getRad () { return radius; }
-	void draw ();
-	std::vector<int> getCoords ()
-	{
-		if (coord.empty ())
-			draw ();
-		return coord;
-	}
-	Circle () {}
-	~Circle () { coord.clear (); }
-	Circle (int x, int y, uint32_t col) : origin (x, y)
-	{
-		color = col;
-		draw ();
-	}
+        void setRad (size_t rad) { radius = rad; }
+        size_t getRad () const { return radius; }
+        /**
+         * @brief Populate the coord vector with perimeter pixels.
+         */
+        void draw ();
+        /**
+         * @brief Get or lazily compute the circle outline coordinates.
+         */
+        const std::vector<int> &getCoords ()
+        {
+                if (coord.empty ())
+                        draw ();
+                return coord;
+        }
+        Circle () {}
+        ~Circle () = default;
+        Circle (int x, int y, uint32_t col) : origin (x, y)
+        {
+                color = col;
+                draw ();
+        }
 };
 
+/**
+ * @brief Axis-aligned rectangle helper used by overlays.
+ */
 class Rectangle
 {
     private:
-	Point origin;
-	Point end;
-	uint32_t color;
-	std::vector<int> coord;
+        Point origin;
+        Point end;
+        uint32_t color;
+        std::vector<int> coord;
 
     public:
-	uint32_t getColor () { return color; }
-	void setColor (uint32_t rgba) { color = rgba; }
+        uint32_t getColor () const { return color; }
+        void setColor (uint32_t rgba) { color = rgba; }
 
-	int getAX ();
-	int getAY ();
-	int getBX ();
-	int getBY ();
+        int getAX () const;
+        int getAY () const;
+        int getBX () const;
+        int getBY () const;
 
-	void setAX (int setX) { origin.setX (setX); }
-	void setAY (int setY) { origin.setY (setY); }
-	void setBX (int setX) { end.setX (setX); }
-	void setBY (int setY) { end.setY (setY); }
-	void draw ();
-	std::vector<int> getCoords ()
-	{
-		if (coord.empty ())
-			draw ();
-		return coord;
-	}
-	Rectangle (int ax, int ay, int bx, int by, uint32_t col)
-	    : origin (ax, ay), end (bx, by)
-	{
-		color = col;
-		draw ();
-	}
-	Rectangle () {}
-	~Rectangle () { coord.clear (); }
+        void setAX (int setX) { origin.setX (setX); }
+        void setAY (int setY) { origin.setY (setY); }
+        void setBX (int setX) { end.setX (setX); }
+        void setBY (int setY) { end.setY (setY); }
+        /**
+         * @brief Compute the rectangle outline into coord.
+         */
+        void draw ();
+        /**
+         * @brief Get or lazily compute the rectangle outline.
+         */
+        const std::vector<int> &getCoords ()
+        {
+                if (coord.empty ())
+                        draw ();
+                return coord;
+        }
+        Rectangle (int ax, int ay, int bx, int by, uint32_t col)
+            : origin (ax, ay), end (bx, by)
+        {
+                color = col;
+                draw ();
+        }
+        Rectangle () {}
+        ~Rectangle () = default;
 };
 
+/**
+ * @brief Triangle primitive with helpers for scanline rasterization.
+ */
 class Triangle
 {
     private:
-	Point a, b, c;
-	uint32_t color;
-	std::vector<int> coord;
+        Point a, b, c;
+        uint32_t color;
+        std::vector<int> coord;
 
     public:
-	uint32_t getColor () { return color; }
-	void setColor (uint32_t rgba) { color = rgba; }
+        uint32_t getColor () const { return color; }
+        void setColor (uint32_t rgba) { color = rgba; }
 
-	int getAX () { return a.getX (); }
-	int getAY () { return a.getY (); }
-	int getBX () { return b.getX (); }
-	int getBY () { return b.getY (); }
-	int getCX () { return c.getX (); }
-	int getCY () { return c.getY (); }
+        int getAX () const { return a.getX (); }
+        int getAY () const { return a.getY (); }
+        int getBX () const { return b.getX (); }
+        int getBY () const { return b.getY (); }
+        int getCX () const { return c.getX (); }
+        int getCY () const { return c.getY (); }
 
-	void setAX (int setX) { a.setX (setX); }
-	void setAY (int setY) { a.setY (setY); }
-	void setBX (int setX) { b.setX (setX); }
-	void setBY (int setY) { b.setY (setY); }
-	void setCX (int setX) { c.setX (setX); }
-	void setCY (int setY) { c.setY (setY); }
+        void setAX (int setX) { a.setX (setX); }
+        void setAY (int setY) { a.setY (setY); }
+        void setBX (int setX) { b.setX (setX); }
+        void setBY (int setY) { b.setY (setY); }
+        void setCX (int setX) { c.setX (setX); }
+        void setCY (int setY) { c.setY (setY); }
 
-	void flatTop (int, int, int, int, int, int);
-	void flatBottom (int, int, int, int, int, int);
-	void draw ();
-	std::vector<int> getCoords ()
-	{
-		if (coord.empty ())
-			draw ();
-		return coord;
-	}
-	Triangle (int ax, int ay, int bx, int by, int cx, int cy, uint32_t col)
-	    : a (ax, ay), b (bx, by), c (cx, cy), color (col)
-	{
-		draw ();
-	}
-	Triangle () {}
-	~Triangle () { coord.clear (); }
+        void flatTop (int, int, int, int, int, int);
+        void flatBottom (int, int, int, int, int, int);
+        /**
+         * @brief Build a filled triangle into the coord buffer.
+         */
+        void draw ();
+        /**
+         * @brief Access the filled triangle pixels, generating them if needed.
+         */
+        const std::vector<int> &getCoords ()
+        {
+                if (coord.empty ())
+                        draw ();
+                return coord;
+        }
+        Triangle (int ax, int ay, int bx, int by, int cx, int cy, uint32_t col)
+            : a (ax, ay), b (bx, by), c (cx, cy), color (col)
+        {
+                draw ();
+        }
+        Triangle () {}
+        ~Triangle () = default;
 };
 
+/**
+ * @brief Arbitrary polygon described by ordered vertices.
+ */
 class Polygon
 {
     private:
-	std::vector<Point> vertex;
-	uint32_t color;
+        std::vector<Point> vertex;
+        uint32_t color;
 
     public:
-	float getX (int vert) { return float (vertex [vert].getX ()); }
-	float getY (int vert) { return float (vertex [vert].getY ()); }
-	uint32_t getColor () { return color; }
-	int count () { return vertex.size (); }
-	void setColor (uint32_t rgba) { color = rgba; }
-	int setVertexes (std::vector<int> coord);
-	float smallestX ();
-	float largestX ();
-	float smallestY ();
-	float largestY ();
+        float getX (int vert) const { return float (vertex [vert].getX ()); }
+        float getY (int vert) const { return float (vertex [vert].getY ()); }
+        uint32_t getColor () const { return color; }
+        size_t count () const { return vertex.size (); }
+        void setColor (uint32_t rgba) { color = rgba; }
+        int setVertexes (std::vector<int> coord);
+        float smallestX ();
+        float largestX ();
+        float smallestY ();
+        float largestY ();
 };
 
+/**
+ * @brief Line segment helper used by the mini-map and debug shapes.
+ */
 class Line
 {
     private:
-	Point origin;
-	Point end;
-	uint32_t color;
-	std::vector<int> coord;
+        Point origin;
+        Point end;
+        uint32_t color;
+        std::vector<int> coord;
 
     public:
-	uint32_t getColor () { return color; }
-	void setColor (uint32_t rgba) { color = rgba; }
+        uint32_t getColor () const { return color; }
+        void setColor (uint32_t rgba) { color = rgba; }
 
-	int getAX () { return origin.getX (); }
-	int getAY () { return origin.getY (); }
-	int getBX () { return end.getX (); }
-	int getBY () { return end.getY (); }
+        int getAX () const { return origin.getX (); }
+        int getAY () const { return origin.getY (); }
+        int getBX () const { return end.getX (); }
+        int getBY () const { return end.getY (); }
 
-	void setAX (int setX) { origin.setX (setX); }
-	void setAY (int setY) { origin.setY (setY); }
-	void setBX (int setX) { end.setX (setX); }
-	void setBY (int setY) { end.setY (setY); }
-	void draw ();
-	std::vector<int> getCoords ()
-	{
-		if (coord.size () < 4)
-			draw ();
-		return coord;
-	}
-	Line (int ax, int ay, int bx, int by, uint32_t col)
-	    : origin (ax, ay), end (bx, by), color (col)
-	{
-		draw ();
-	}
-	Line (int ax, int ay, int bx, int by)
-	    : origin (ax, ay), end (bx, by)
-	{
-		draw ();
-	}
-	void reinit (int ax, int ay, int bx, int by)
-	{
-			origin.setX (ax);
-			origin.setY (ay);
-			end.setX (bx);
-			end.setY (by);
-			draw ();
-	}
-	Line () {}
-	~Line () { coord.clear (); }
+        void setAX (int setX) { origin.setX (setX); }
+        void setAY (int setY) { origin.setY (setY); }
+        void setBX (int setX) { end.setX (setX); }
+        void setBY (int setY) { end.setY (setY); }
+        /**
+         * @brief Use Bresenham-style plotting to build the line coordinates.
+         */
+        void draw ();
+        /**
+         * @brief Access the plotted line pixels, generating them if necessary.
+         */
+        const std::vector<int> &getCoords ()
+        {
+                if (coord.size () < 4)
+                        draw ();
+                return coord;
+        }
+        Line (int ax, int ay, int bx, int by, uint32_t col)
+            : origin (ax, ay), end (bx, by), color (col)
+        {
+                draw ();
+        }
+        Line (int ax, int ay, int bx, int by)
+            : origin (ax, ay), end (bx, by)
+        {
+                draw ();
+        }
+        void reinit (int ax, int ay, int bx, int by)
+        {
+                        origin.setX (ax);
+                        origin.setY (ay);
+                        end.setX (bx);
+                        end.setY (by);
+                        draw ();
+        }
+        Line () {}
+        ~Line () = default;
 };
 
 #endif // GEO_PRIMS_H

--- a/include/map.h
+++ b/include/map.h
@@ -3,18 +3,44 @@
 
 #include <cstdlib>
 
+/**
+ * @brief 2D grid describing the raycaster world.
+ *
+ * Map currently stores a small, hard-coded tile array (walls are positive
+ * integers, empty cells are zero). It exposes simple helpers that make it easy
+ * for collision detection and ray casting to query whether a location is
+ * blocked.
+ */
 class Map
 {
     public:
-	size_t w, h;
+        size_t w, h;
 
-	Map ();
-	int get (const size_t iX, const size_t iY) const;
-	bool isEmpty (const size_t iX, const size_t iY) const;
-	size_t getArea () { return w * h; }
-	size_t getW () { return w; }
-	size_t getH () { return h; }
-	// Add a default spawn spot in each map?
+        /**
+         * @brief Construct the default map with built-in layout.
+         */
+        Map ();
+        /**
+         * @brief Fetch the raw tile value at a given coordinate.
+         */
+        int get (const size_t iX, const size_t iY) const;
+        /**
+         * @brief Check whether a map cell can be traversed.
+         */
+        bool isEmpty (const size_t iX, const size_t iY) const;
+        /**
+         * @brief Total number of tiles (width * height).
+         */
+        size_t getArea () { return w * h; }
+        /**
+         * @brief Map width in tiles.
+         */
+        size_t getW () { return w; }
+        /**
+         * @brief Map height in tiles.
+         */
+        size_t getH () { return h; }
+        // Add a default spawn spot in each map?
 };
 
 #endif // MAP_H

--- a/include/overlay.h
+++ b/include/overlay.h
@@ -4,11 +4,20 @@
 #ifndef OVERLAY_H
 #define OVERLAY_H
 
+/**
+ * @brief Off-screen buffer that can be composited onto the main framebuffer.
+ *
+ * Overlays are used for HUD-style elements such as the mini-map. They carry a
+ * small canvas plus the screen offset where they should be blended.
+ */
 struct Overlay
 {
-	std::size_t offsetX, offsetY;
-	std::size_t h, w;
-	std::vector<uint32_t> canvas;
+        /// X/Y offsets into the destination framebuffer.
+        std::size_t offsetX, offsetY;
+        /// Overlay dimensions in pixels.
+        std::size_t h, w;
+        /// Pixel buffer holding overlay contents.
+        std::vector<uint32_t> canvas;
 }; // Overlay
 
 #endif // OVERLAY_H

--- a/include/player.h
+++ b/include/player.h
@@ -3,36 +3,83 @@
 #ifndef PLAYER_H
 #define PLAYER_H
 
+/**
+ * @brief Represents the controllable camera within the world.
+ *
+ * Player tracks position, facing direction, and simple movement intent flags
+ * (turn/walk). Input handling code updates these flags; the render and
+ * collision systems query the resulting position and angle to drive the
+ * raycaster.
+ */
 class Player
 {
     private:
-	int turn = 0;
-	int walk = 0;
-	float x, y;
-	float angle = 0.;
+        int turn = 0;
+        int walk = 0;
+        float x, y;
+        float angle = 0.;
 
     public:
-	float fov;
- // float altitude;
- // this will be used with the algorithm to determine view point
- // though I need to add a camera header that is attached (usually) to players head
-	int horizon;
-	// float tilt; // head movement LR
-	float getAngle () const { return angle; }
-	void stopTurn () { turn = 0; }
-	void stopMove () { walk = 0; }
-	void initTurn (int dir);
-	void initMove (int dir);
-	float getX () const { return x; }
-	float getY () const { return y; }
-	void moveLoc (int dir, float *targetX, float *targetY);
-	// Is this dirty? It feels like I could use the constructor
-	// But how do I construct from the GameState class by calling the spawn
-	// function
-	// I think I need the spawn function for other uses
-	void spawn (float, float, float, float, int);
-	Player () {}
-	Player (float, float, float, float, int);
+        /// Horizontal field-of-view in radians.
+        float fov;
+        // float altitude;
+        // this will be used with the algorithm to determine view point
+        // though I need to add a camera header that is attached (usually) to players head
+        /// Screen-space horizon line used to split sky and floor drawing.
+        int horizon;
+        // float tilt; // head movement LR
+
+        /**
+         * @brief Current facing angle in radians.
+         */
+        float getAngle () const { return angle; }
+        /**
+         * @brief Clear any pending turn input.
+         */
+        void stopTurn () { turn = 0; }
+        /**
+         * @brief Clear any pending walk input.
+         */
+        void stopMove () { walk = 0; }
+        /**
+         * @brief Begin turning left (-1) or right (+1).
+         */
+        void initTurn (int dir);
+        /**
+         * @brief Begin walking forward (+1) or backward (-1).
+         */
+        void initMove (int dir);
+        /**
+         * @brief Player position along the X axis.
+         */
+        float getX () const { return x; }
+        /**
+         * @brief Player position along the Y axis.
+         */
+        float getY () const { return y; }
+        /**
+         * @brief Predict a movement step without immediately applying it.
+         *
+         * Used by collision detection to test whether the next step would
+         * intersect a wall. The proposed target coordinates are written to
+         * @p targetX and @p targetY.
+         */
+        void moveLoc (int dir, float *targetX, float *targetY);
+        // Is this dirty? It feels like I could use the constructor
+        // But how do I construct from the GameState class by calling the spawn
+        // function
+        // I think I need the spawn function for other uses
+        /**
+         * @brief Initialize player position and camera configuration.
+         * @param xPos Starting X coordinate (map units).
+         * @param yPos Starting Y coordinate (map units).
+         * @param fovRads Field of view in radians.
+         * @param ang    Initial facing angle in radians.
+         * @param horiz  Horizon line in screen pixels.
+         */
+        void spawn (float, float, float, float, int);
+        Player () {}
+        Player (float, float, float, float, int);
 };
 
 #endif // PLAYER_H

--- a/include/render.h
+++ b/include/render.h
@@ -9,18 +9,40 @@
 #ifndef RENDER_H
 #define RENDER_H
 
+/**
+ * @brief Aggregates the live state used by the renderer.
+ *
+ * GameState bundles the map, player, sprite list, and textures so that the
+ * render loop and input handling can share a single lightweight structure.
+ */
 class GameState
 {
     public:
-	Map map;
-	Player player;
-	std::vector<Sprite> monsters;
-	Texture texWalls;
-	Texture texMonsters;
-	void spawn (int height);
-	GameState (Map, Player, std::vector<Sprite>, std::string, std::string);
+        Map map;
+        Player player;
+        std::vector<Sprite> monsters;
+        Texture texWalls;
+        Texture texMonsters;
+        /**
+         * @brief Spawn the player at the first open cell and set screen params.
+         * @param height Height of the output framebuffer in pixels (for horizon).
+         */
+        void spawn (int height);
+        /**
+         * @brief Construct a fully-initialized game state.
+         * @param map Map to use for rendering and collision.
+         * @param player Player camera instance.
+         * @param sprites Initial list of monsters to render.
+         * @param texName Path to wall texture atlas.
+         * @param spriteTexName Path to monster texture atlas.
+         */
+        GameState (Map, Player, std::vector<Sprite>, std::string, std::string);
 
 }; // gamestate
+
+/**
+ * @brief Draw a single frame using the current GameState into the framebuffer.
+ */
 void render (FrameBuffer &fb, const GameState &gs);
 
 #endif // RENDER_H

--- a/include/sprite.h
+++ b/include/sprite.h
@@ -3,12 +3,22 @@
 
 #include <cstdlib>
 
+/**
+ * @brief Billboards rendered after walls for enemies and objects.
+ */
 struct Sprite
 {
-	float x, y;
-	size_t texID;
-	float playerDist;
-	bool operator< (const Sprite &s) const;
+        /// World-space position in map units.
+        float x, y;
+        /// Index into the monster texture atlas.
+        size_t texID;
+        /// Cached distance from player, used for painter's sorting.
+        float playerDist;
+
+        /**
+         * @brief Sort sprites from farthest to nearest for correct overlap.
+         */
+        bool operator< (const Sprite &s) const;
 };
 
 #endif // SPRITE_H

--- a/include/textures.h
+++ b/include/textures.h
@@ -5,21 +5,45 @@
 #include <string>
 #include <vector>
 
+/**
+ * @brief Loads and samples horizontally packed texture atlases.
+ *
+ * The engine expects a single image that contains N square textures placed side
+ * by side. Texture exposes helpers for loading that image, sampling an
+ * individual texel, and building a vertically scaled column suited for wall or
+ * sprite rendering.
+ */
 class Texture
 {
     public:
-	size_t imgWidth, imgHeight;
-	size_t count, size;
-	std::vector<uint32_t> img;
+        size_t imgWidth, imgHeight;
+        size_t count, size;
+        std::vector<uint32_t> img;
 
-	Texture (const std::string filename);
-	uint32_t get (const size_t iX,
-		      const size_t iY,
-		      const size_t texID) const; // Get a pixel from texture
-	std::vector<uint32_t> getScaledColumn (const size_t texID,
-					       const size_t texCoord,
-					       const size_t columnHeight)
-		const; // Retrieve a column from texID and scale it correctly
+        /**
+         * @brief Load a texture atlas from disk.
+         * @param filename Path to a PNG compatible with stb_image.
+         */
+        Texture (const std::string filename);
+        /**
+         * @brief Sample a single texel from a specific texture slice.
+         * @param iX X coordinate inside the square slice.
+         * @param iY Y coordinate inside the square slice.
+         * @param texID Zero-based index of the slice to sample.
+         */
+        uint32_t get (const size_t iX,
+                      const size_t iY,
+                      const size_t texID) const; // Get a pixel from texture
+        /**
+         * @brief Extract and scale a vertical column for rendering.
+         * @param texID Index of the slice to sample from the atlas.
+         * @param texCoord Horizontal coordinate within the slice.
+         * @param columnHeight Desired height of the scaled column in pixels.
+         */
+        std::vector<uint32_t> getScaledColumn (const size_t texID,
+                                               const size_t texCoord,
+                                               const size_t columnHeight)
+                const; // Retrieve a column from texID and scale it correctly
 };
 
 #endif // TEXTURES_H

--- a/include/utils.h
+++ b/include/utils.h
@@ -5,16 +5,28 @@
 #include <string>
 #include <vector>
 
+/**
+ * @brief Pack RGBA channels into a 32-bit integer.
+ */
 uint32_t packColor (const uint8_t r,
-		    const uint8_t g,
-		    const uint8_t b,
-		    const uint8_t a = 255);
+                    const uint8_t g,
+                    const uint8_t b,
+                    const uint8_t a = 255);
+/**
+ * @brief Split a packed RGBA value back into separate channels.
+ */
 void unpackColor (
-	const uint32_t &color, uint8_t &r, uint8_t &g, uint8_t &b, uint8_t &a);
+        const uint32_t &color, uint8_t &r, uint8_t &g, uint8_t &b, uint8_t &a);
+/**
+ * @brief Write a framebuffer image to disk as a binary PPM file.
+ */
 void dropPPMImage (const std::string filename,
-		   const std::vector<uint32_t> &image,
-		   const size_t w,
-		   const size_t h);
+                   const std::vector<uint32_t> &image,
+                   const size_t w,
+                   const size_t h);
+/**
+ * @brief Alpha blend a foreground pixel onto a background pixel.
+ */
 uint32_t overlay (const uint32_t bgColor, const uint32_t fgColor);
 
 #endif // UTILS_H

--- a/src/geo-prims.cpp
+++ b/src/geo-prims.cpp
@@ -3,24 +3,25 @@
 
 #include <geo-prims.h>
 
-int Rectangle::getAX ()
+int Rectangle::getAX () const
 {
 	return (origin.getX () < end.getX ()) ? origin.getX () : end.getX ();
 }
-int Rectangle::getAY ()
+int Rectangle::getAY () const
 {
 	return (origin.getY () < end.getY ()) ? origin.getY () : end.getY ();
 }
-int Rectangle::getBX ()
+int Rectangle::getBX () const
 {
 	return (end.getX () > origin.getX ()) ? end.getX () : origin.getX ();
 }
-int Rectangle::getBY ()
+int Rectangle::getBY () const
 {
 	return (end.getY () > origin.getY ()) ? end.getY () : origin.getY ();
 }
 void Rectangle::draw ()
 {
+        coord.clear ();
 	const size_t rw = getBX () - getAX ();
 	const size_t rh = getBY () - getAY ();
 	const int cx	= getAX ();
@@ -41,17 +42,15 @@ void Triangle::flatTop (int ax, int ay, int bx, int by, int cx, int cy)
 	float closeX  = (float) cx;
 	float farX    = (float) cx;
 
-	for (int row = cy; row > ay; --row)
-	{
-		Line line ((int) closeX, row, (int) farX, row);
-		std::vector<int> lineCoords = line.getCoords ();
-		coord.insert (
-			coord.end (), lineCoords.begin (), lineCoords.end ());
-		for (size_t i = 0; i < coord.size (); i++)
-			std::cout << coord [i] << " ";
-		closeX -= iSlope1;
-		farX -= iSlope2;
-	}
+        for (int row = cy; row > ay; --row)
+        {
+                Line line ((int) closeX, row, (int) farX, row);
+                const std::vector<int> &lineCoords = line.getCoords ();
+                coord.insert (
+                        coord.end (), lineCoords.begin (), lineCoords.end ());
+                closeX -= iSlope1;
+                farX -= iSlope2;
+        }
 }
 void Triangle::flatBottom (int ax, int ay, int bx, int by, int cx, int cy)
 {
@@ -61,15 +60,15 @@ void Triangle::flatBottom (int ax, int ay, int bx, int by, int cx, int cy)
 	float closeX  = (float) ax;
 	float farX    = (float) ax;
 
-	for (int row = ay; row <= by; ++row)
-	{
-		Line line ((int) closeX, row, (int) farX, row);
-		std::vector<int> lineCoords = line.getCoords ();
-		coord.insert (
-			coord.end (), lineCoords.begin (), lineCoords.end ());
-		closeX += iSlope1;
-		farX += iSlope2;
-	}
+        for (int row = ay; row <= by; ++row)
+        {
+                Line line ((int) closeX, row, (int) farX, row);
+                const std::vector<int> &lineCoords = line.getCoords ();
+                coord.insert (
+                        coord.end (), lineCoords.begin (), lineCoords.end ());
+                closeX += iSlope1;
+                farX += iSlope2;
+        }
 }
 
 void Triangle::draw ()
@@ -160,7 +159,8 @@ void Triangle::draw ()
 
 void Circle::draw ()
 {
-	int x	   = getX ();
+        coord.clear ();
+        int x	   = getX ();
 	int y	   = getY ();
 	size_t rad = getRad ();
 
@@ -293,7 +293,8 @@ float Polygon::largestY ()
 }
 void Line::draw ()
 {
-	int ax = origin.getX ();
+        coord.clear ();
+        int ax = origin.getX ();
 	int ay = origin.getY ();
 	int bx = end.getX ();
 	int by = end.getY ();
@@ -448,8 +449,5 @@ void Line::draw ()
 		}
 	}
 
-	std::cout << coord.size ();
-	for (size_t i = 0; i < coord.size (); i++)
-		std::cout << coord [i] << " ";
 }
 


### PR DESCRIPTION
## Summary
- make geometry primitive accessors const-correct and avoid unnecessary iostream dependency
- clear cached coordinate buffers before re-rendering shapes and remove leftover debug output

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e7f07df848325940b15798fbb4497)